### PR TITLE
Fix #1 by removing handlebars from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "helpers"
   ],
   "dependencies": {
-    "extend": "^2.0.0",
-    "handlebars": "^3.0.1"
+    "extend": "^2.0.0"
   }
 }


### PR DESCRIPTION
This plugin needs to use the project's version of handlebars, not its own.