### PR TITLE
Add handlebars as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "standard": "^4.4.0"
+  },
+  "peerDependencies": {
+    "handlebars": ">1.0.0"
   }
 }


### PR DESCRIPTION
Installing this library without `handlebars` leads to a `Module not found` error. Good use-case for [npm peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).